### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/lmfit_example.py
+++ b/lmfit_example.py
@@ -19,7 +19,7 @@ def lmfit_ngauss(x,y, *params):
   mods = []
   prefixes = []
   for i in range(0, len(params), 3):
-    pref = "g%02i_" % (i/3)
+    pref = "g{0:02d}_".format((i/3))
     gauss_i = GaussianModel(prefix=pref)
 
     if i == 0:
@@ -59,7 +59,7 @@ def lmfit_ngauss_constrains(x,y, params, constrains):
   mods = []
   prefixes = []
   for i in range(0, len(params), 3):
-    pref = "g%02i_" % (i/3)
+    pref = "g{0:02d}_".format((i/3))
     gauss_i = GaussianModel(prefix=pref)
 
     if i == 0:

--- a/lmfit_mngauss.py
+++ b/lmfit_mngauss.py
@@ -29,7 +29,7 @@ def lmfit_mngauss(x,y, *params):
     m_mods = []
     prefixes = []
     for i in range(0, len(m_params), 3):
-        pref = "gm%02i_" % (i/3)
+        pref = "gm{0:02d}_".format((i/3))
         gauss_i = GaussianModel(prefix=pref)
 
         if i == 0:
@@ -63,7 +63,7 @@ def lmfit_mngauss(x,y, *params):
         n_mods = []
         #prefixes = []
         for j in range(0, len(n_params), 3):
-            pref = "gn%02i_" % (j/3)
+            pref = "gn{0:02d}_".format((j/3))
             gauss_j = GaussianModel(prefix=pref)
             pars.update(gauss_j.make_params())
         

--- a/lmfit_ngauss.py
+++ b/lmfit_ngauss.py
@@ -25,7 +25,7 @@ def lmfit_ngauss(x,y, params):
   mods = []
   prefixes = []
   for i in range(0, len(params), 3):
-    pref = "g%02i_" % (i/3)
+    pref = "g{0:02d}_".format((i/3))
     gauss_i = GaussianModel(prefix=pref)
 
     if i == 0:
@@ -74,7 +74,7 @@ def lmfit_ngauss_constrains(x,y, params, constrains):
   mods = []
   prefixes = []
   for i in range(0, len(params), 3):
-    pref = "g%02i_" % (i/3)
+    pref = "g{0:02d}_".format((i/3))
     gauss_i = GaussianModel(prefix=pref)
 
     if i == 0:


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:jason-neal:lmfit_test_examples?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:jason-neal:lmfit_test_examples?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)